### PR TITLE
Correct path of coder.png image

### DIFF
--- a/404-to-301.php
+++ b/404-to-301.php
@@ -37,7 +37,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 if(!defined('I4T3_PATH')){
-	define( 'I4T3_PATH', home_url( PLUGINDIR . '/404-to-301/' ) );
+	define( 'I4T3_PATH', WP_PLUGIN_URL . '/404-to-301/' );
 }
 if(!defined('I4T3_PLUGIN_DIR')) {
 	define( 'I4T3_PLUGIN_DIR', __FILE__ );

--- a/admin/partials/404-to-301-admin-general-tab.php
+++ b/admin/partials/404-to-301-admin-general-tab.php
@@ -94,7 +94,7 @@
 				<tr>
 					<th><?php _e( 'Exclude paths', '404-to-301' ); ?></th>
 					<td>
-						<textarea rows="5" cols="50" placeholder="http://example.com&#13;&#10;wp-content/plugins/abc-plugin/css/" name="i4t3_gnrl_options[exclude_paths]"><?php echo $options['exclude_paths']; ?></textarea>
+						<textarea rows="5" cols="50" placeholder="http://example.com/wp-content/plugins/abc-plugin/css/" name="i4t3_gnrl_options[exclude_paths]"><?php echo $options['exclude_paths']; ?></textarea>
 						<p class="description"><?php _e( 'If you want to exclude few paths from error logs, enter here. One per line.', '404-to-301' ); ?>.</p>
 					</td>
 				</tr>


### PR DESCRIPTION
PLUGINDIR is depracated
Used WP_PLUGIN_URL instead according https://codex.wordpress.org/Determining_Plugin_and_Content_Directories

This corrects the issue https://github.com/joel-james/404-to-301/issues/3