### PR TITLE
Add localization to hardcoded texts

### DIFF
--- a/admin/class-404-to-301-admin.php
+++ b/admin/class-404-to-301-admin.php
@@ -389,7 +389,7 @@ class _404_To_301_Admin {
 		
 		// Dump the plugin settings data
 		if( !empty( $gnrl_options ) ) {
-			$html 	.=	'<h4>Settings Data</h4>
+			$html 	.=	'<h4>'.__( 'Settings Data', '404-to-301' ).'</h4>
 							<p><pre>';
 			foreach ( $gnrl_options as $key => $option ) {
 				$html 	.=	$key.' : '.$option.'<br/>';
@@ -397,27 +397,27 @@ class _404_To_301_Admin {
 			$html 	.=	'</pre></p><hr/>';
 		}
 		// Output basic info about the site
-		$html 	.=	'<h4>Basic Details</h4>
+		$html 	.=	'<h4>'.__( 'Basic Details', '404-to-301').'</h4>
 						<p>
-							WordPress Version : '. get_bloginfo('version') .'<br/>
-							PHP Version : '. PHP_VERSION .'<br/>
-							Plugin Version : '. $this->version .'<br/>
-							Home Page : '. home_url() .'<br/>
+							'.__( 'WordPress Version', '404-to-301').' : '. get_bloginfo('version' ) .'<br/>
+							'.__( 'PHP Version', '404-to-301').' : '. PHP_VERSION .'<br/>
+							'.__( 'Plugin Version', '404-to-301').' : '. $this->version .'<br/>
+							'.__( 'Home Page', '404-to-301').' : '. home_url() .'<br/>
 						</p><hr/>';
 
 		if ( $active_theme->exists() ) {
 
-			$html 	.=	'<h4>Active Theme Details</h4>
+			$html 	.=	'<h4>'.__( 'Active Theme Details', '404-to-301' ).'</h4>
 							<p>
-								Name : '. $active_theme->get( 'Name' ) .'<br/>
-								Version : '. $active_theme->get( 'Version' ) .'<br/>
-								Theme URI : '. $active_theme->get( 'ThemeURI' ) .'<br/>
+								'.__( 'Name', '404-to-301').' : '. $active_theme->get( 'Name' ) .'<br/>
+								'.__( 'Version', '404-to-301').' : '. $active_theme->get( 'Version' ) .'<br/>
+								'.__( 'Theme URI', '404-to-301').' : '. $active_theme->get( 'ThemeURI' ) .'<br/>
 							</p><hr/>';
 		}
 		
 		// Dump the active plugins data
 		if( !empty( $active_plugins ) ) {
-			$html 	.=	'<h4>Active Plugins</h4>
+			$html 	.=	'<h4>'.__( 'Active Plugins', '404-to-301' ).'</h4>
 							<p>';
 			foreach ( $active_plugins as $plugin ) {
 				$html 	.=	$plugin.'<br/>';

--- a/admin/class-404-to-301-admin.php
+++ b/admin/class-404-to-301-admin.php
@@ -185,7 +185,7 @@ class _404_To_301_Admin {
 		add_submenu_page(
 			'i4t3-logs',
 			__( '404 to 301 Settings', '404-to-301' ),
-			'404 Settings', 
+			__( '404 Settings', '404-to-301' ),
 			I4T3_ADMIN_PERMISSION, 
 			'i4t3-settings',
 			array( $this, 'i4t3_admin_page' )

--- a/admin/partials/404-to-301-admin-credits-tab.php
+++ b/admin/partials/404-to-301-admin-credits-tab.php
@@ -12,7 +12,7 @@
 							</div>
 							<div class="c4p-left" style="width: 70%">
 							<?php $uname = ( $current_user->user_firstname == '' ) ? $current_user->user_login : $current_user->user_firstname; ?>
-								<p>Yo <strong><?php echo $uname; ?></strong>! <?php _e( 'Thank you for using 404 to 301', '404-to-301' ); ?></p>
+								<p><?php printf( __( 'Yo %s!', '404-to-301' ), '<strong>'.$uname.'</strong>' ); ?> <?php _e( 'Thank you for using 404 to 301', '404-to-301' ); ?></p>
 								<p>
 									<?php _e( 'This plugin is brought to you by', '404-to-301' ); ?> <a href="http://iscode.co/" class="i4t3-author-link" target="_blank" title="<?php _e( 'Visit author website', '404-to-301' ); ?>"><strong>is_code()</strong></a>, <?php _e( 'a web store developed and managed by Joel James.', '404-to-301' ); ?>
 								</p>

--- a/admin/partials/404-to-301-admin-general-tab.php
+++ b/admin/partials/404-to-301-admin-general-tab.php
@@ -95,7 +95,7 @@
 					<th><?php _e( 'Exclude paths', '404-to-301' ); ?></th>
 					<td>
 						<textarea rows="5" cols="50" placeholder="http://example.com&#13;&#10;wp-content/plugins/abc-plugin/css/" name="i4t3_gnrl_options[exclude_paths]"><?php echo $options['exclude_paths']; ?></textarea>
-						<p class="description"><?php _e( 'If you want to exclude few paths from error logs, enter here. One per line.', '404-to-301' ); ?>.</p>
+						<p class="description"><?php _e( 'If you want to exclude few paths from error logs, enter here. One per line.', '404-to-301' ); ?></p>
 					</td>
 				</tr>
 			</tbody>


### PR DESCRIPTION
Added translation to the following:
`Yo admin!` (transformed in complete phrase for better context understanding by translators)

`Settings Data`
	`Basic Details`
	`WordPress Version`
	`PHP Version`
	`Plugin Version`
	`Home Page`
	`Name`
	`Version`
	`Theme URI`

`Active Theme Details`

`Active Plugins`