### PR TITLE
Correct path of coder.png image

### DIFF
--- a/404-to-301.php
+++ b/404-to-301.php
@@ -37,7 +37,7 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 if(!defined('I4T3_PATH')){
-	define( 'I4T3_PATH', home_url( PLUGINDIR . '/404-to-301/' ) );
+	define( 'I4T3_PATH', WP_PLUGIN_URL . '/404-to-301/' );
 }
 if(!defined('I4T3_PLUGIN_DIR')) {
 	define( 'I4T3_PLUGIN_DIR', __FILE__ );


### PR DESCRIPTION
PLUGINDIR is depracated
Used WP_PLUGIN_URL instead according https://codex.wordpress.org/Determining_Plugin_and_Content_Directories

This corrects the issue https://github.com/joel-james/404-to-301/issues/3