### PR TITLE
Add textdomain to hardcoded text and punctuation

### DIFF
--- a/admin/partials/404-to-301-admin-agreement-tab.php
+++ b/admin/partials/404-to-301-admin-agreement-tab.php
@@ -45,8 +45,8 @@
     </div>
 
     <div>
-        <a class="button-primary" href="<?php echo I4T3_SETTINGS_PAGE; ?>&i4t3_agreement=1" id="i4t3-accept-terms">I accept</a>
-        <a class="button-secondary" href="<?php echo I4T3_SETTINGS_PAGE; ?>&i4t3_agreement=0" id="i4t3-hide-admin-notice">I do not accept</a>
+        <a class="button-primary" href="<?php echo I4T3_SETTINGS_PAGE; ?>&i4t3_agreement=1" id="i4t3-accept-terms"><?php _e('I accept', '404-to-301'); ?></a>
+        <a class="button-secondary" href="<?php echo I4T3_SETTINGS_PAGE; ?>&i4t3_agreement=0" id="i4t3-hide-admin-notice"><?php _e('I do not accept', '404-to-301'); ?></a>
     </div>
     </span>
 </div>

--- a/admin/partials/404-to-301-admin-credits-tab.php
+++ b/admin/partials/404-to-301-admin-credits-tab.php
@@ -73,9 +73,9 @@ if( get_option( 'i4t3_agreement', 2 ) == 2 ) {
                         </div>
                         <div class="misc-pub-section">
                             <?php if( get_option( 'i4t3_agreement', 2 ) == 1 ) { ?>
-                            <a class="button-secondary" href="<?php echo I4T3_HELP_PAGE; ?>&i4t3_agreement=0" id="i4t3-hide-admin-notice">Disable UAN</a>
+                            <a class="button-secondary" href="<?php echo I4T3_HELP_PAGE; ?>&i4t3_agreement=0" id="i4t3-hide-admin-notice"><?php _e('Disable UAN', '404-to-301'); ?></a>
                             <?php } else { ?>
-                            <a class="button-primary" href="<?php echo I4T3_HELP_PAGE; ?>&i4t3_agreement=1" id="i4t3-accept-terms">Enable UAN</a>
+                            <a class="button-primary" href="<?php echo I4T3_HELP_PAGE; ?>&i4t3_agreement=1" id="i4t3-accept-terms"><?php _e('Enable UAN', '404-to-301'); ?></a>
                             <?php } ?>
                         </div>
                     </div>
@@ -84,9 +84,9 @@ if( get_option( 'i4t3_agreement', 2 ) == 2 ) {
                     <h3 class="hndle ui-sortable-handle"><span class="dashicons dashicons-admin-plugins"></span> <?php _e('Log Manager Addon', '404-to-301'); ?></h3>
                     <div class="inside">
                         <div class="misc-pub-section">
-                            <p><?php _e('Error Log Manager addon is available for 404 to 301 now. Make 404 error management more easy', '404-to-301'); ?>.</p>
-                            <p><span class="dashicons dashicons-backup"></span> <?php _e('Instead of email alerts on every error, get Hourly, Daily, Twice a day, Weekly, Twice a week email alerts', '404-to-301'); ?>.</p>
-                            <p><span class="dashicons dashicons-trash"></span> <?php _e('Automatically clear old error logs after few days to reduce db load', '404-to-301'); ?>.</p>
+                            <p><?php _e('Error Log Manager addon is available for 404 to 301 now. Make 404 error management more easy.', '404-to-301'); ?></p>
+                            <p><span class="dashicons dashicons-backup"></span> <?php _e('Instead of email alerts on every error, get Hourly, Daily, Twice a day, Weekly, Twice a week email alerts.', '404-to-301'); ?></p>
+                            <p><span class="dashicons dashicons-trash"></span> <?php _e('Automatically clear old error logs after few days to reduce db load.', '404-to-301'); ?></p>
                             <p><a class="i4t3-author-link" href="https://thefoxe.com/products/404-to-301-log-manager/" target="_blank"><span class="dashicons dashicons-external"></span> <?php _e('See More Details', '404-to-301'); ?></a></p>
                         </div>
                     </div>


### PR DESCRIPTION
Add translation to **I accept**, **I do not accept**, **Disable UAN**, **Enable UAN**
Moved **.** punctuation inside of string, to avoid duplication in case translators include it.

The license itself is way too big to make it translatable :)

There is a hardcoded string in https://github.com/joel-james/404-to-301/blob/master/admin/js/admin.js#L50 script file, the **Redirect** title of the popup to customize redirection.
I don't know how to move it to php file to be captured by a gettext function, the best I can do is report it here.