### PR TITLE
Suggestion for admin 404 Error Log table

### DIFF
--- a/admin/class-404-to-301-logs.php
+++ b/admin/class-404-to-301-logs.php
@@ -268,7 +268,7 @@ class _404_To_301_Logs extends WP_List_Table_404 {
 
         $title = ( ! empty( $item['redirect'] ) ) ? $item['redirect'] : __( 'Default', '404-to-301' );
         
-        return '<a href="javascript:void(0)" title="' . $title . '" class="i4t3_redirect_thickbox" url_404="' . $item['url'] . '">' . __('Update', '404-to-301') . '</a>';
+        return '<a href="javascript:void(0)" title="' .  __('Customize', '404-to-301') . '" class="i4t3_redirect_thickbox" url_404="' . $item['url'] . '">' . $title . '</a>';
     }
 
     /**
@@ -397,12 +397,12 @@ class _404_To_301_Logs extends WP_List_Table_404 {
 
         $columns = array(
             'cb' => '<input type="checkbox" style="width: 5%;" />',
-            'date' => __( 'When', '404-to-301' ),
+            'date' => __( 'Date', '404-to-301' ),
             'url' => __( '404 Path', '404-to-301' ),
-            'ref' => __( 'Came From', '404-to-301' ), // referer
+            'ref' => __( 'From', '404-to-301' ), // referer
             'ip' => __( 'IP Address', '404-to-301' ),
             'ua' => __('User Agent', '404-to-301'),
-            'redirect' => __( 'Custom Redirect', '404-to-301' )
+            'redirect' => __( 'Redirect', '404-to-301' )
         );
 
         return $columns;


### PR DESCRIPTION
The current columns:
When | 404 Path | Came From | IP Address | User Agent | Custom Redirect

The proposed changes:
**Date** | 404 Path | **From** | IP Address | User Agent | **Redirect**

Reasons:
**Date** is a wider used term, direct.
**From** is simple, shorter and direct.
**Redirect** is shorter, direct, and comply with the below changes I've also made to the content of the column.
For the **Redirect** column data, the data isn't in the hover title but actually listed, wich is better for sorting purposes and can be read right away, without hovering. The current **Update** term isn't also correct, might be better something like "Customize" as the options are **Default** or the _customized URL_. So I've kept the hover text with "Customize".

**BEFORE**
![before](https://cloud.githubusercontent.com/assets/7371591/15745045/a4d390a6-28c7-11e6-9312-eb388baa573e.png)

**AFTER**
![after](https://cloud.githubusercontent.com/assets/7371591/15745051/b5c8e384-28c7-11e6-9390-0575eefd7adc.png)


Hope you enjoy it :+1: 