### PR TITLE
Make the email alert Inform which plugin sent it

### DIFF
--- a/includes/public/class-jj4t3-404-email.php
+++ b/includes/public/class-jj4t3-404-email.php
@@ -209,6 +209,7 @@ class JJ4T3_404_Email {
 		$message .= '<td align="left">' . $this->error_data->ref . '</td>';
 		$message .= '</tr>';
 		$message .= '</table>';
+		$message .= 'Alert sent by the 404-to-301 plugin for Wordpress';
 
 		/**
 		 * Filter to alter email content.

--- a/includes/public/class-jj4t3-404-email.php
+++ b/includes/public/class-jj4t3-404-email.php
@@ -209,7 +209,8 @@ class JJ4T3_404_Email {
 		$message .= '<td align="left">' . $this->error_data->ref . '</td>';
 		$message .= '</tr>';
 		$message .= '</table>';
-		$message .= 'Alert sent by the 404-to-301 plugin for Wordpress';
+		// Who sent me this alert?
+		$message .= '<p>Alert sent by the 404-to-301 plugin for Wordpress.</p>';
 
 		/**
 		 * Filter to alter email content.


### PR DESCRIPTION
Let Wordpress admins know which plugin sent the 404 alert.