### PR TITLE
Display X-Geo-Country info

### DIFF
--- a/includes/public/class-jj4t3-404-data.php
+++ b/includes/public/class-jj4t3-404-data.php
@@ -60,6 +60,14 @@ class JJ4T3_404_Data {
 	public $time = '';
 
 	/**
+	 * Visitor's Country (available through a CDN, which must send the info in the X-Geo-Country header)
+	 *
+	 * @var    string
+	 * @access public
+	 */
+	public $geo_country = '';
+
+	/**
 	 * Initialize the class.
 	 *
 	 * @since  3.0.0
@@ -72,6 +80,7 @@ class JJ4T3_404_Data {
 		$this->set_ua();
 		$this->set_url();
 		$this->set_time();
+		$this->set_geo_country(); // if available through the X-Geo-Country header
 	}
 
 	/**
@@ -202,6 +211,25 @@ class JJ4T3_404_Data {
 		$this->time = apply_filters( 'jj4t3_404_time', current_time( 'mysql' ) );
 	}
 
+	/**
+	 * Set the visitor's country if available through the X-Geo-Country HTTP header.
+	 *
+	 * @since  3.0.0
+	 * @access private
+	 *
+	 * @return void
+	 */
+
+    private function set_geo_country() {
+	if (array_key_exists('HTTP_X_GEO_COUNTRY', $_SERVER)) {
+           	return  $_SERVER["HTTP_X_GEO_COUNTRY"];  
+     	} else { 
+       		return 'N/A';
+	}    
+    }
+	
+	
+	
 	/**
 	 * Exclude specified paths from 404.
 	 *

--- a/includes/public/class-jj4t3-404-data.php
+++ b/includes/public/class-jj4t3-404-data.php
@@ -221,11 +221,15 @@ class JJ4T3_404_Data {
 	 */
 
 	 private function set_geo_country() {
-		if (array_key_exists('HTTP_X_GEO_COUNTRY', $_SERVER)) {
-           		$this->geo_country = apply_filters( 'jj4t3_404_geo_country', $_SERVER["HTTP_X_GEO_COUNTRY"]);  
-		} else { 
-        	      	$this->geo_country = apply_filters( 'jj4t3_404_geo_country', 'N/A');
-		}    
+
+		if ( isset( $_SERVER['HTTP_X_GEO_COUNTRY'] ) ) {
+			$geo_country = esc_geo_country( $_SERVER['HTTP_X_GEO_COUNTRY'] );
+		} else {
+			$geo_country = 'N/A';
+		}
+		 
+           	$this->geo_country = apply_filters( 'jj4t3_404_geo_country', $geo_country);  
+	
 	}
 	
 	

--- a/includes/public/class-jj4t3-404-data.php
+++ b/includes/public/class-jj4t3-404-data.php
@@ -220,13 +220,13 @@ class JJ4T3_404_Data {
 	 * @return void
 	 */
 
-    private function set_geo_country() {
-	if (array_key_exists('HTTP_X_GEO_COUNTRY', $_SERVER)) {
-           	return  $_SERVER["HTTP_X_GEO_COUNTRY"];  
-     	} else { 
-       		return 'N/A';
-	}    
-    }
+	 private function set_geo_country() {
+		if (array_key_exists('HTTP_X_GEO_COUNTRY', $_SERVER)) {
+           		$this->geo_country = apply_filters( 'jj4t3_404_geo_country', $_SERVER["HTTP_X_GEO_COUNTRY"]);  
+		} else { 
+        	      	$this->geo_country = apply_filters( 'jj4t3_404_geo_country', 'N/A');
+		}    
+	}
 	
 	
 	

--- a/includes/public/class-jj4t3-404-email.php
+++ b/includes/public/class-jj4t3-404-email.php
@@ -198,6 +198,11 @@ class JJ4T3_404_Email {
 		$message .= '<th align="left">' . __( 'IP Address', JJ4T3_DOMAIN ) . '</th>';
 		$message .= '<td align="left">' . $this->error_data->ip . '</td>';
 		$message .= '</tr>';
+		// Visitor's country if available through X-Geo-Country HTTP header.
+		$message .= '<tr>';
+	        $message .= '<th align="left">' . __('Visitor Country', JJ4T3_DOMAIN ) . '</th>';
+        	$message .= '<td align="left">' . $this->error_data->geo_country . '</td>';
+	        $message .= '</tr>';
 		// Date and time.
 		$message .= '<tr>';
 		$message .= '<th align="left">' . __( 'Time', JJ4T3_DOMAIN ) . '</th>';

--- a/includes/public/class-jj4t3-404-logging.php
+++ b/includes/public/class-jj4t3-404-logging.php
@@ -79,13 +79,15 @@ class JJ4T3_404_Logging {
 	 */
 	private function get_data() {
 
-		// Set error data fields.
+		// Set error data fields. 
 		$data = array(
 			'date' => $this->data->time,
 			'ip' => $this->data->ip,
 			'url' => $this->data->url,
 			'ref' => $this->data->ref,
 			'ua' => $this->data->ua,
+			// New geo_country field
+			'geo_country' => $this->data->geo_country,
 		);
 
 		// If a custom redirect is set.


### PR DESCRIPTION
Motivation: wouldn't it be nice to display the visitor's location in the 404 alert email? This way the Wordpress admin won't have to waste time looking for this information online. 
The X-Geo-Country header isn't available by default but may be added if the website uses a CDN (the wordpress admin might need to contact their CDN support to enable it).
This is a sample alert with the X-Geo-Country set:
<img width="489" alt="with x-geo-country - 404-to-301 plugin" src="https://user-images.githubusercontent.com/8276617/31851929-ca2cb3fa-b66f-11e7-98ac-8f93ff7dd5d0.png">
And this is an example when it doesn't exist:
<img width="511" alt="without x-geo-country - 404-to-301 plugin" src="https://user-images.githubusercontent.com/8276617/31851933-da1fd1a2-b66f-11e7-9ec9-580bbdb623f1.png">
@Joel-James, you may want to review my modifications. I admit I didn't understand what the apply_filter function does but used it anyway to keep your code consistent. For example in line 231 of the file class-jj4t3-404-data.php. Luckily it seems to work. :)