### PR TITLE
Fix nonce verification bug

### DIFF
--- a/includes/admin/class-jj4t3-log-listing.php
+++ b/includes/admin/class-jj4t3-log-listing.php
@@ -765,7 +765,7 @@ class JJ4T3_Log_Listing extends WP_List_Table {
 		$nonce = jj4t3_from_request( '_wpnonce' );
 
 		// Nonce verification.
-		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'bulk-404errorlogs' ) ) {
+		if ( empty( $nonce ) || ! wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
When trying to execute delete or bulk action, the nonce verification failed when the instance used another language as nonce action context didn't match.